### PR TITLE
Ahora el "en camino" de /dafi lo envía a los interesados

### DIFF
--- a/bot/handlers/rooms.py
+++ b/bot/handlers/rooms.py
@@ -109,7 +109,7 @@ def cmd_dafi(update: Update, context: CallbackContext[dict, dict, dict]) -> None
         context.bot_data['room_queue'] = queue
 
     if action == RoomActions.ON:
-        if user.telegram_id in members:
+        if user in members:
             update.effective_message.reply_text(
                 'Ya tenía constancia de que estás en DAFI ⚠️'
             )
@@ -201,15 +201,13 @@ def callback_dafi(update: Update, context: CallbackContext[dict, dict, dict]) ->
             )
             return
 
-        group_id = Config.get(Config.MAIN_GROUP_ID)
-
         try:
-            assert group_id is not None
+            for member_id in members_ids:
+                context.bot.send_message(
+                    member_id,
+                    f'¡{update.effective_user.name} está de camino a DAFI!',
+                )
 
-            context.bot.send_message(
-                group_id,
-                f'¡{update.effective_user.name} está de camino a DAFI!',
-            )
         except (TelegramError, AssertionError):
             update.effective_message.reply_text(
                 'No he podido avisarles 😓'

--- a/bot/handlers/rooms.py
+++ b/bot/handlers/rooms.py
@@ -109,7 +109,7 @@ def cmd_dafi(update: Update, context: CallbackContext[dict, dict, dict]) -> None
         context.bot_data['room_queue'] = queue
 
     if action == RoomActions.ON:
-        if user in members:
+        if user.telegram_id in members_ids:
             update.effective_message.reply_text(
                 'Ya tenía constancia de que estás en DAFI ⚠️'
             )
@@ -195,24 +195,28 @@ def callback_dafi(update: Update, context: CallbackContext[dict, dict, dict]) ->
     members = list(User.objects.filter(telegram_id__in=members_ids))
 
     if action == 'omw':
+        failed_messages = 0
         if not members:
             query.edit_message_text(
                 'Ahora mismo no hay nadie en DAFI 😓'
             )
             return
 
-        try:
-            for member_id in members_ids:
+        for member_id in members_ids:
+            try:    
                 context.bot.send_message(
                     member_id,
                     f'¡{update.effective_user.name} está de camino a DAFI!',
                 )
 
-        except (TelegramError, AssertionError):
+            except:
+                failed_messages += 1
+                return
+        
+        if failed_messages > 0:
             update.effective_message.reply_text(
-                'No he podido avisarles 😓'
-            )
-            return
+                    'No he podido avisarles 😓'
+                )
 
         query.edit_message_reply_markup() # To remove the button
 


### PR DESCRIPTION
Hay dos cambios a la vez en este commit:

- Antes, por la forma del código, el bot simplemente se saltaba la comprobación de si un mismo usuario ya estaba en DAFI. Esto se traduce en que un mismo usuario podía poner /dafi on las veces que quisiera, que el bot no le avisaba de que ya estaba ahí, lo que también producía un problema a la hora de enviar un mensaje a los interesados, ya que se guardaba el UID de Telegram tantas veces como el usuario pusiera /dafi on y le podía mandar 5, 6, 7 mensajes (o tantas veces como el usuario haya hecho /dafi on) de que x usuario estaba de camino a DAFI.

- Ahora, si un usuario dice que está de camino, el bot manda un mensaje de "¡@x está de camino a DAFI!" tan solo a los que estén ahí, no al grupo general.